### PR TITLE
Add motion mode support for H1_2

### DIFF
--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         arm_ctrl = G1_23_ArmController(motion_mode=args.motion, simulation_mode=args.sim)
     elif args.arm == "H1_2":
         arm_ik = H1_2_ArmIK()
-        arm_ctrl = H1_2_ArmController(simulation_mode=args.sim)
+        arm_ctrl = H1_2_ArmController(motion_mode=args.motion, simulation_mode=args.sim)
     elif args.arm == "H1":
         arm_ik = H1_ArmIK()
         arm_ctrl = H1_ArmController(simulation_mode=args.sim)


### PR DESCRIPTION
Changes:
- Add motion_mode parameter to H1_2_ArmController constructor
- Use kTopicLowCommand_Motion publisher when motion_mode is enabled
- Add motion control logic in motor state control loop
- Add gradual weight transition during homing sequence for motion mode
- Update main teleop script to pass motion mode flag to H1_2_ArmController

Other Notes:
- This fixes #139
- Based on changes in #116 and advice from [motion mode wiki](https://github.com/unitreerobotics/xr_teleoperate/wiki/%E2%80%90%E2%80%90motion-Mode)
- Tested successfully on the H1_2