### PR TITLE
fix(g1): walk on sw 1.5.3 via FSM 1->4->501 (Start()/500 is ignored)

### DIFF
--- a/teleop/fsm_explore.py
+++ b/teleop/fsm_explore.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Interactive G1 high-level FSM explorer — find the transition path from FSM 802 (the R2+A
+"Running" mode) to a walkable state (main operation control / FSM 500) on sw 1.5.3.
+
+SAFETY: robot on the gantry / supported, e-stop ready. Some FSM ids cause motion or make the
+robot limp (0 = zero-torque, 1 = damp). Try gentle transitions and WATCH the robot each time.
+
+RUN (tv env):  python fsm_explore.py <interface>       e.g. python fsm_explore.py enxf8e43b46612e
+
+At the  fsm>  prompt:
+   <number>   SetFsmId(number), then print the resulting FSM id
+   v          send vx=0.1 for ~2s  (does the CURRENT FSM actually walk? watch the feet) then stop
+   g          just GetFsmId
+   q          quit (damps first for safety)
+
+Reference ids: 0 zero-torque | 1 damp | 3 sit | 500 main-control(walk) | 702 lie2stand | 706 squat2stand
+Suggested probes from 802:   1  ->g->  500 ->g-> v     and     706 ->g-> v
+"""
+import sys
+import time
+
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+
+
+def main():
+    iface = sys.argv[1] if len(sys.argv) > 1 else "enxf8e43b46612e"
+    ChannelFactoryInitialize(0, iface)
+    c = LocoClient()
+    c.SetTimeout(3.0)
+    c.Init()
+
+    def show():
+        code, fid = c.GetFsmId()
+        print(f"     -> FSM id = {fid}   (GetFsmId code {code})")
+        return fid
+
+    print("G1 FSM explorer.  commands: <number>=SetFsmId | v=test-walk 2s | g=GetFsmId | q=quit")
+    print("ids: 0 zero-torque | 1 damp | 3 sit | 500 main-control(walk) | 702 lie2stand | 706 squat2stand")
+    show()
+    while True:
+        try:
+            cmd = input("fsm> ").strip().lower()
+        except EOFError:
+            break
+        if cmd == "q":
+            c.SetFsmId(1)
+            print("damped. bye")
+            break
+        elif cmd == "g":
+            show()
+        elif cmd == "v":
+            print("     sending vx=0.1 for ~2s (watch the feet)...")
+            for _ in range(20):
+                c.SetVelocity(0.1, 0.0, 0.0, 1.0)
+                time.sleep(0.1)
+            c.SetVelocity(0.0, 0.0, 0.0)
+            print("     stopped")
+        elif cmd.lstrip("-").isdigit():
+            code = c.SetFsmId(int(cmd))
+            print(f"     SetFsmId({cmd}) -> code {code}")
+            time.sleep(1.3)
+            show()
+        else:
+            print("     ? enter a number, or v / g / q")
+
+
+if __name__ == "__main__":
+    main()

--- a/teleop/loco_test.py
+++ b/teleop/loco_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Minimal G1 locomotion isolation test (high-level LocoClient) — for debugging the sw-1.5.3
+walk issue WITHOUT the full xr_teleoperate stack (no televuer, no arm IK, no cameras).
+
+It prints every FSM state and every return code so we can see EXACTLY where it breaks.
+
+PREREQS
+  - Robot ON, on a gantry / clear space, e-stop ready.
+  - Robot in the HIGH-LEVEL motion-control mode (the built-in 'sport' service must be RUNNING).
+    NOTE: this is the OPPOSITE of the L2+R2 debug mode used for the GEAR-SONIC low-level deploy.
+    On fw 1.5.3, R1+X ("Regular") is reportedly rejected — R2+A ("Running") is what engages
+    motion-control. Enter that first, then run this. If GetFsmId below returns nonzero, the
+    sport service isn't reachable (wrong mode / interface / service name).
+
+RUN (in the tv env, which has unitree_sdk2py):
+    conda activate tv
+    python loco_test.py <interface>          e.g.  python loco_test.py enxf8e43b46612e
+"""
+import sys
+import time
+
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+from unitree_sdk2py.g1.loco.g1_loco_api import LOCO_SERVICE_NAME
+
+
+def fsm(c, label):
+    code, fid = c.GetFsmId()
+    print(f"[loco_test] GetFsmId {label:16s} -> code={code}  fsm_id={fid}")
+    return code, fid
+
+
+def main():
+    iface = sys.argv[1] if len(sys.argv) > 1 else "enxf8e43b46612e"
+    print(f"[loco_test] interface={iface}   service={LOCO_SERVICE_NAME!r}  (G1 uses 'sport')")
+    ChannelFactoryInitialize(0, iface)          # 0 = real robot
+    c = LocoClient()
+    c.SetTimeout(3.0)                            # generous so we see real errors, not timeouts
+    c.Init()
+    print("[loco_test] LocoClient Init done\n")
+
+    # 1) Is the sport service responding at all?
+    code, fid = fsm(c, "(current)")
+    if code != 0:
+        print("\n  >>> sport service NOT responding (code != 0).")
+        print("      Likely: robot in DEBUG mode (sport off) / wrong interface / service-name mismatch.")
+        print("      Fix the robot mode first (motion-control, NOT L2+R2 debug), then re-run.")
+        return
+
+    # 2) Try to enter FSM 500 (Start / main operation control)
+    code = c.SetFsmId(500)
+    print(f"[loco_test] SetFsmId(500)=Start   -> code={code}   (0=ok; nonzero e.g. 3102 = rejected/lease)")
+    time.sleep(1.5)
+    fsm(c, "(after Start)")
+
+    # 3) Send a small forward velocity — use SetVelocity directly (Move() discards the code)
+    ans = input("\n[loco_test] Robot supported/clear? Type 'go' to send vx=0.1 for ~2s (anything else = skip): ")
+    if ans.strip().lower() == "go":
+        for i in range(20):
+            code = c.SetVelocity(0.1, 0.0, 0.0, duration=1.0)
+            if i % 5 == 0:
+                print(f"[loco_test] SetVelocity(0.1,0,0) -> code={code}")
+            time.sleep(0.1)
+        c.SetVelocity(0.0, 0.0, 0.0)
+        print("[loco_test] velocity zeroed.")
+
+    print("\n[loco_test] done. Report the FSM ids + codes above — that pins down the 1.5.3 failure:")
+    print("  - GetFsmId code!=0            -> service/mode problem (not in motion-control).")
+    print("  - SetFsmId(500) code!=0       -> FSM transition rejected (Run-mode conflict / lease).")
+    print("  - fsm stays != 500 after Start-> robot won't leave its current FSM (e.g. stuck in Run mode).")
+    print("  - SetVelocity code!=0         -> velocity command rejected in current FSM.")
+
+
+if __name__ == "__main__":
+    main()

--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -350,11 +350,12 @@ if __name__ == '__main__':
                     STOP = True
                 # command robot to enter damping mode. soft emergency stop function
                 if tele_data.left_ctrl_thumbstick and tele_data.right_ctrl_thumbstick:
-                    loco_wrapper.Damp()
-                # https://github.com/unitreerobotics/xr_teleoperate/issues/135, control, limit velocity to within 0.3
-                loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
-                                  -tele_data.left_ctrl_thumbstickValue[0] * 0.3,
-                                  -tele_data.right_ctrl_thumbstickValue[0]* 0.3)
+                    loco_wrapper.Enter_Damp_Mode()   # fix PR#310: wrapper has Enter_Damp_Mode(), not Damp()
+                else:
+                    # https://github.com/unitreerobotics/xr_teleoperate/issues/135, control, limit velocity to within 0.3
+                    loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
+                                      -tele_data.left_ctrl_thumbstickValue[0] * 0.3,
+                                      -tele_data.right_ctrl_thumbstickValue[0]* 0.3)
 
             # get current robot state data.
             current_lr_arm_q  = arm_ctrl.get_current_dual_arm_q()

--- a/teleop/utils/motion_switcher.py
+++ b/teleop/utils/motion_switcher.py
@@ -33,8 +33,42 @@ class MotionSwitcher:
 class LocoClientWrapper:
     def __init__(self):
         self.client = LocoClient()
-        self.client.SetTimeout(0.0001)
+        self.client.SetTimeout(1.0)     # generous timeout for the FSM handshake
         self.client.Init()
+        self._enter_control_mode()      # G1 sw 1.5.3: reach the walkable state via 1 -> 4 -> 501 (see below)
+        self.client.SetTimeout(0.0001)  # fast, non-blocking for the high-rate Move loop
+
+    def _enter_control_mode(self):
+        """Bring the G1 into its walkable 'main operation control' state on sw 1.5.3.
+
+        The SDK's Start() sets FSM 500, but this firmware ignores it: from the R2+A "Running" mode
+        (FSM 802), SetFsmId(500) returns success yet the robot never leaves 802. Verified on-robot,
+        the walkable state on 1.5.3 is FSM 501, reached via: damp(1) -> stand(4) -> main-control(501).
+        SetVelocity/Move only take effect once in 501. (Override the target with G1_CTRL_FSM if a
+        future firmware changes it.)
+
+        The stand-up (4) is a PHYSICAL motion that takes several seconds; SetFsmId(501) is silently
+        ignored until it finishes (the FSM sticks at 4). So we wait, then RETRY 501 until GetFsmId
+        confirms we actually reached it.
+        """
+        import os
+        target = int(os.environ.get("G1_CTRL_FSM", "501"))
+        self.client.SetFsmId(1)          # damp
+        time.sleep(1.0)
+        self.client.SetFsmId(4)          # stand up — physical motion, takes a few seconds
+        time.sleep(5.0)
+        fid = None
+        for attempt in range(1, 13):     # retry 501 until it takes (stand-up timing varies)
+            self.client.SetFsmId(target)
+            time.sleep(1.0)
+            _, fid = self.client.GetFsmId()
+            if fid == target:
+                break
+        if fid == target:
+            print(f"[LocoClientWrapper] control mode reached: FSM id = {target} (attempt {attempt})")
+        else:
+            print(f"[LocoClientWrapper] WARNING: FSM id = {fid}, wanted {target} after {attempt} tries "
+                  f"— robot may not have finished standing; increase the stand wait.")
 
     def Enter_Damp_Mode(self):
         self.client.Damp()

--- a/teleop/wrapper_test.py
+++ b/teleop/wrapper_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Quick isolated test of the FIXED LocoClientWrapper (damp(1) -> stand(4) -> 501 on G1 sw 1.5.3).
+Confirms the wrapper's automated FSM sequence + timing reach the walkable state and that Move walks,
+without bringing up the full teleop (no televuer / arms / cameras).
+
+SAFETY: robot on the gantry / supported, e-stop ready (it damps then stands at startup).
+RUN (tv env):  python wrapper_test.py <interface>     e.g. python wrapper_test.py enxf8e43b46612e
+"""
+import os
+import sys
+import time
+
+# make `teleop.utils.motion_switcher` importable (xr_teleoperate repo root on sys.path)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+from teleop.utils.motion_switcher import LocoClientWrapper
+
+iface = sys.argv[1] if len(sys.argv) > 1 else "enxf8e43b46612e"
+print(f"[wrapper_test] iface={iface} — building LocoClientWrapper (runs damp -> stand -> 501)...")
+ChannelFactoryInitialize(0, iface)          # 0 = real robot
+w = LocoClientWrapper()                       # should print 'control mode: FSM id = 501'
+
+input("[wrapper_test] FSM id = 501 above? ENTER to Move forward ~2s (GANTRY!): ")
+for _ in range(20):
+    w.Move(0.1, 0.0, 0.0)
+    time.sleep(0.1)
+w.Move(0.0, 0.0, 0.0)
+print("[wrapper_test] done — if the feet stepped, the locomotion fix works end-to-end via the wrapper.")


### PR DESCRIPTION
On G1 sw 1.5.3 the SDK's LocoClient.Start() sets FSM 500, which this firmware ignores: from the R2+A Running mode (FSM 802), SetFsmId(500) returns success but the robot never leaves 802 and won't walk. Verified on-robot, the walkable main-control state is FSM 501, reached via damp(1) -> stand(4) -> 501. LocoClientWrapper now runs that sequence on startup (waiting for the physical stand-up and retrying 501 until GetFsmId confirms it); G1_CTRL_FSM overrides the target. Also: Enter_Damp_Mode rename (https://github.com/unitreerobotics/xr_teleoperate/pull/310) and three on-robot debug tools (loco_test, fsm_explore, wrapper_test).

Resolves https://github.com/unitreerobotics/unitree_sdk2_python/issues/170