### PR TITLE
[fix] clamp teleop controller thumbstick input range to [-1, 1]

### DIFF
--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -354,9 +354,13 @@ if __name__ == '__main__':
                 if tele_data.left_ctrl_thumbstick and tele_data.right_ctrl_thumbstick:
                     loco_wrapper.Damp()
                 # https://github.com/unitreerobotics/xr_teleoperate/issues/135, control, limit velocity to within 0.3
-                loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
-                                  -tele_data.left_ctrl_thumbstickValue[0] * 0.3,
-                                  -tele_data.right_ctrl_thumbstickValue[0]* 0.3)
+                # Clamp controller thumbstick axes to [-1, 1] before scaling: XR controllers
+                # report thumbstick axes in this range, and any value outside it is invalid
+                # input that must not reach locomotion control unscaled.
+                loco_vx = max(-1.0, min(1.0, -tele_data.left_ctrl_thumbstickValue[1])) * 0.3
+                loco_vy = max(-1.0, min(1.0, -tele_data.left_ctrl_thumbstickValue[0])) * 0.3
+                loco_wz = max(-1.0, min(1.0, -tele_data.right_ctrl_thumbstickValue[0])) * 0.3
+                loco_wrapper.Move(loco_vx, loco_vy, loco_wz)
 
             # get current robot state data.
             current_lr_arm_q  = arm_ctrl.get_current_dual_arm_q()


### PR DESCRIPTION
## Summary

Teleoperation inputs received from the XR headset (controller thumbstick/trigger/squeeze
axes and hand-tracking frames) are currently forwarded to motion control without range
validation. This change clamps every analog input to its physically meaningful range
before it reaches locomotion, arm IK, or hand retargeting, and rejects malformed or
non-finite telemetry frames instead of forwarding them.

## Background

`teleop_hand_and_arm.py` scales controller thumbstick values by `0.3` and passes the
result directly to `loco_wrapper.Move(...)`. XR controller thumbsticks report axes in
`[-1, 1]`; a value outside that range would be scaled and forwarded to locomotion
control as-is, which is not a valid input for the motion controller. The same applies
to the `televuer` input handlers, which accept pose matrices and analog state values
from the network without any sanity check.

Robustness principle: every value that crosses the network boundary into motion control
should be validated at the boundary and again at the point of use.

## Changes

### `teleop/teleop_hand_and_arm.py` (xr_teleoperate)

- Clamp each thumbstick axis to `[-1, 1]` before applying the existing `0.3` scaling in
  `loco_wrapper.Move(...)`. Values outside this range are invalid controller input and
  are now bounded to the nearest valid value instead of being forwarded unscaled.

### `src/televuer/televuer.py` (televuer submodule)

- `_clamp_input()`: clamps a scalar input to a given range; non-numeric and non-finite
  values are replaced by a safe default (`0.0`) with a warning.
- `_valid_pose_matrix()`: rejects pose matrices that are not 16 finite floats or whose
  translation components fall outside a plausible working volume.
- `_valid_hand_frame()`: rejects hand frames that are malformed, non-finite, or outside
  a plausible working volume.
- `on_controller_move`: validate left/right pose matrices before writing them to the
  shared arm-pose buffers; clamp `triggerValue`/`squeezeValue` to `[0, 1]` and
  `thumbstickValue` axes to `[-1, 1]`.
- `on_hand_move`: validate left/right hand frames before writing them to the shared
  buffers; clamp `pinchValue`/`squeezeValue` to `[0, 1]`.

All rejections only skip the offending frame and log a warning — they never crash the
handler or the server.

## Why this is needed

- Safety: bounded inputs guarantee that locomotion and arm/hand control only ever
  receive values within their designed ranges, regardless of what arrives on the
  network.
- Robustness: malformed or non-finite telemetry (e.g. `NaN`/`Inf` from a broken
  client) previously flowed into control math; it is now rejected with a warning.
- No behavior change for normal operation: real XR devices already produce values
  within the clamped ranges.

## Testing

Local (no hardware required):

1. `python -m py_compile teleop/teleop_hand_and_arm.py` and
   `python -m py_compile src/televuer/televuer.py`.
2. Unit-check `_clamp_input`: `0.4 → 0.4`; `2.5 → 1.0`; `-5.0 → -1.0`;
   `NaN`/`Inf`/`"abc"`/`None → 0.0`.
3. Unit-check `_valid_pose_matrix`: 16 finite floats with small translation → accepted;
   translation component `1e6` → rejected; `NaN` → rejected.
4. Unit-check `_valid_hand_frame`: 25×16 finite frame with wrist at `0.4 m` → accepted;
   wrist at `1e6` → rejected.

On hardware:

- Run teleoperation in controller mode and confirm normal walking speeds are unchanged;
  push both thumbsticks fully to one side and confirm the resulting velocity matches the
  previous maximum.
- Run in hand-tracking mode and confirm hand retargeting behaves identically.

## Compatibility

- No API, schema, or configuration changes.
- All bounds are generous relative to real-world values (analog axes in `[-1, 1]`,
  poses within ±10 m of the tracking origin), so normal VR operation is unaffected.
- Existing clients and the Vuer-based web UI require no changes.

## Suggested follow-up (operations hardening, not part of this PR)

When teleoperating a real robot over a shared network, we recommend restricting access
to the teleop server (e.g. bind to a trusted interface or use a firewall such as
`ufw`) so that only the operator's device can reach the teleop port. This change makes
the control path robust to out-of-range inputs; network-level access control additionally
limits who can send inputs at all.

## Note on repositories

`src/televuer/televuer.py` lives in the `unitreerobotics/televuer` repository, which
`xr_teleoperate` consumes as a git submodule. This PR contains the
`teleop/teleop_hand_and_arm.py` change for `unitreerobotics/xr_teleoperate`; the
`televuer.py` change should be submitted as a companion PR to
`unitreerobotics/televuer` (or bundled here with a submodule pointer update, if
preferred).
