### PR TITLE
[fix] Fix controller damping shortcut (for soft emergency stop function) and show startup warning

### DIFF
--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -268,6 +268,8 @@ if __name__ == '__main__':
         else:
             logger_mp.info("🔵  Recording is DISABLED (run with --record to enable).")
         logger_mp.info("🔴  Press [q] to stop and exit the program.")
+        if args.input_mode == "controller" and args.motion:
+            logger_mp.warning("⚠️  During tracking, press both controller thumbsticks down simultaneously to request damping mode (soft emergency stop). Use only when necessary.")
         logger_mp.info("⚠️  IMPORTANT: Please keep your distance and stay safe.")
         READY = True                  # now ready to (1) enter START state
         while not START and not STOP: # wait for start or stop signal.
@@ -352,7 +354,7 @@ if __name__ == '__main__':
                     STOP = True
                 # command robot to enter damping mode. soft emergency stop function
                 if tele_data.left_ctrl_thumbstick and tele_data.right_ctrl_thumbstick:
-                    loco_wrapper.Damp()
+                    loco_wrapper.Enter_Damp_Mode()
                 # https://github.com/unitreerobotics/xr_teleoperate/issues/135, control, limit velocity to within 0.3
                 loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
                                   -tele_data.left_ctrl_thumbstickValue[0] * 0.3,


### PR DESCRIPTION
This is a bug of the current soft emergency stop function: pressing both controller thumbsticks during motion teleoperation calls `LocoClientWrapper.Damp()`, which does not exist. This raises `AttributeError` and enters cleanup instead of requesting damping mode. Call the existing `Enter_Damp_Mode()` wrapper method, which delegates to the SDK client's `Damp()`.

Also show a startup warning when `--input-mode controller --motion` is enabled, explaining that pressing both thumbsticks simultaneously during tracking requests damping mode (soft emergency stop). This reduces the chance of accidental trigger of soft emergency stop.

Validation: Python syntax and `git diff --check` passed. A mocked SDK check covered all four thumbstick button combinations and confirmed damping is requested only when both are pressed. Tested on the Unitree G1 29 Arm model to confirm the soft emergency behavior is now working.
